### PR TITLE
[UPDATE-ENV_EXAMPLE] Add `REDIS_URL` Configuration and Update Documentation with Yarn Commands

### DIFF
--- a/.env.exapmle
+++ b/.env.exapmle
@@ -14,3 +14,4 @@ DB_DATABASE=
 DB_MAX_CONNECTIONS=         # 100
 DB_SSL_ENABLED=             #false
 DB_REJECT_UNAUTHORIZED=     #false
+REDIS_URL=

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ DB_DATABASE=
 DB_MAX_CONNECTIONS=         # 100
 DB_SSL_ENABLED=             #false
 DB_REJECT_UNAUTHORIZED=     #false
+REDIS_URL=
 ```
 ### Setup PostgreSQL and Redis with Docker
 ```bash


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | Yes |

## Problem

- Lack of configuration for Redis URL in the environment variables example file.
- Documentation and scripts using `npm` instead of `yarn`, which may not align with the project's package manager preference.

## Solution

- Added a new configuration variable `REDIS_URL` to the `.env.example` file to facilitate Redis connection configuration.
- Updated the README to include `REDIS_URL` in the list of environment variables and replaced all `npm` commands with their `yarn` equivalents for consistency.

## Test results
_Add your screenshots or recording about testing_

## Other changes
- None

## Deploy Notes

There are no new dependencies, scripts, or environment variables introduced with this PR, except for the newly added `REDIS_URL`.

**New environment variables**:

- `REDIS_URL`: This variable is used to configure the connection to a Redis instance.