### PR TITLE
[FIX-GET-ALL-EVENTS] Enhance `getAll` Method for Events Retrieval with Role-Based Conditions

### DIFF
--- a/src/modules/events/events.c.ts
+++ b/src/modules/events/events.c.ts
@@ -30,7 +30,7 @@ class EventsController {
     async getAll(req: Request, res: Response, next: NextFunction) {
         try {
             const _req = req as CustomUserRequest;
-            if (!_req.body.brand_id) {
+            if (!_req.body.brand_id && _req.user.role === ROLES.BUSINESS) {
                 req.body.brand_id = _req.user.uid;
             }
             const events = await EventsService.getAll(_req.body.brand_id);

--- a/src/modules/events/events.s.ts
+++ b/src/modules/events/events.s.ts
@@ -54,15 +54,26 @@ export class EventsService {
     }
 
     async getAll(id: string) {
+        if(id)
+        {
+            return await this.eventRepository.find({
+                where: {
+                    brand_id: id,
+                },
+                order: {
+                    start: 'DESC',
+                }
+            });
+        }
+        else
+        {
+            return await this.eventRepository.find({
+                order: {
+                    start: 'DESC',
+                }
+            });
+        }
 
-        return await this.eventRepository.find({
-            where: {
-                brand_id: id,
-            },
-            order: {
-                start: 'DESC',
-            }
-        });
     }
 
     async getById(id: string) {


### PR DESCRIPTION
| Status  | Type  | Env Vars Change |
| :---: | :---: | :---: |
| Ready | Feature | No |

## Problem

- The `getAll` method in the `EventsController` and `EventsService` classes did not adequately handle scenarios where `brand_id` was missing for users with a `BUSINESS` role.
- There was a need to filter events based on the presence of an `id` parameter, affecting how events are retrieved and ordered.

## Solution

- Added a condition in the `EventsController` class to set `brand_id` to the user's UID when it is missing in the request body and the user's role is `BUSINESS`.
- Modified the `getAll` method in the `EventsService` class to include a conditional check for an `id` parameter, retrieving events filtered by `brand_id` or retrieving all events based on its presence, both ordered by `start` in descending order.

## Test results

_Add your screenshots or recording about testing_

## Other changes

- None

## Deploy Notes

There are no new dependencies, scripts, or environment variables introduced with this PR.